### PR TITLE
Add background image, Change the color of status bar and fixing bug text overflow

### DIFF
--- a/lib/screens/detailed.screens.dart
+++ b/lib/screens/detailed.screens.dart
@@ -74,6 +74,7 @@ class DetailScreen extends StatelessWidget {
           children: [
             Expanded(
               child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   Hero(
                     tag: "user_image_$index",
@@ -93,6 +94,7 @@ class DetailScreen extends StatelessWidget {
                         fontWeight: FontWeight.bold,
                         fontSize: 33,
                       ),
+                      textAlign: TextAlign.center,
                     ),
                   ),
                 ],
@@ -105,50 +107,51 @@ class DetailScreen extends StatelessWidget {
     );
   }
 
-  Container _buildCommentPanel(Size displaySize, BuildContext context) {
-    return Container(
-      height: 500,
-      width:
-          768 < displaySize.width ? displaySize.width / 1 : displaySize.width,
-      decoration: BoxDecoration(
-        color: Theme.of(context).scaffoldBackgroundColor,
-        borderRadius: BorderRadius.only(
-          topLeft: Radius.circular(15),
-          topRight: Radius.circular(15),
+  Widget _buildCommentPanel(Size displaySize, BuildContext context) {
+    return Expanded(
+      child: Container(
+        width:
+            768 < displaySize.width ? displaySize.width / 1 : displaySize.width,
+        decoration: BoxDecoration(
+          color: Theme.of(context).scaffoldBackgroundColor,
+          borderRadius: BorderRadius.only(
+            topLeft: Radius.circular(15),
+            topRight: Radius.circular(15),
+          ),
         ),
-      ),
-      child: Padding(
-        padding: displaySize.width > 1000
-            ? EdgeInsets.fromLTRB(200, 0, 200, 0)
-            : displaySize.width > 768
-                ? EdgeInsets.fromLTRB(50, 0, 50, 0)
-                : displaySize.width > 480
-                    ? EdgeInsets.fromLTRB(25, 0, 25, 0)
-                    : EdgeInsets.fromLTRB(5, 0, 5, 0),
-        child: SingleChildScrollView(
-          child: Column(
-            children: [
-              SizedBox(
-                height: 25,
-              ),
-              Container(
-                height: 5,
-                width: 75,
-                decoration: BoxDecoration(
-                    color: Theme.of(context).scaffoldBackgroundColor ==
-                            Colors.black
-                        ? Colors.white60
-                        : Colors.grey.withOpacity(0.3),
-                    borderRadius: BorderRadius.all(Radius.circular(25))),
-              ),
-              SizedBox(
-                height: 25,
-              ),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(25, 0, 25, 0),
-                child: _buildCommentBubble(context, displaySize),
-              )
-            ],
+        child: Padding(
+          padding: displaySize.width > 1000
+              ? EdgeInsets.fromLTRB(200, 0, 200, 0)
+              : displaySize.width > 768
+                  ? EdgeInsets.fromLTRB(50, 0, 50, 0)
+                  : displaySize.width > 480
+                      ? EdgeInsets.fromLTRB(25, 0, 25, 0)
+                      : EdgeInsets.fromLTRB(5, 0, 5, 0),
+          child: SingleChildScrollView(
+            child: Column(
+              children: [
+                SizedBox(
+                  height: 25,
+                ),
+                Container(
+                  height: 5,
+                  width: 75,
+                  decoration: BoxDecoration(
+                      color: Theme.of(context).scaffoldBackgroundColor ==
+                              Colors.black
+                          ? Colors.white60
+                          : Colors.grey.withOpacity(0.3),
+                      borderRadius: BorderRadius.all(Radius.circular(25))),
+                ),
+                SizedBox(
+                  height: 25,
+                ),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(25, 0, 25, 0),
+                  child: _buildCommentBubble(context, displaySize),
+                )
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/screens/home_view.dart
+++ b/lib/screens/home_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
 import '../constants/assets.dart';
@@ -58,36 +59,39 @@ class _HomeViewState extends State<HomeView> {
     return GestureDetector(
       onTap: () => FocusManager.instance.primaryFocus
           ?.unfocus(), // dismiss keyboard when user tap on the outside of textfield
-      child: Scaffold(
-        body: SafeArea(
-          bottom: false,
-          child: Stack(
-            children: [
-              Container(
-                width: w,
-                height: h,
-                decoration: BoxDecoration(
-                  image: DecorationImage(
-                    image: AssetImage(bgImage),
-                    fit: BoxFit.fill,
+      child: AnnotatedRegion<SystemUiOverlayStyle>(
+        value: isDark ? SystemUiOverlayStyle.light : SystemUiOverlayStyle.dark,
+        child: Scaffold(
+          body: SafeArea(
+            bottom: false,
+            child: Stack(
+              children: [
+                Container(
+                  width: w,
+                  height: h,
+                  decoration: BoxDecoration(
+                    image: DecorationImage(
+                      image: AssetImage(bgImage),
+                      fit: BoxFit.fill,
+                    ),
                   ),
                 ),
-              ),
-              Center(
-                child: SizedBox(
-                  width: isLandscape ? w * 0.5 : w,
-                  child: NestedScrollView(
-                    headerSliverBuilder: (c, bo) => [
-                      _buildLogoHeader(isDark),
-                      _buildSearchBar(context),
-                    ],
-                    body: isLoading
-                        ? Center(child: CircularProgressIndicator())
-                        : ListingFragment(data: users),
+                Center(
+                  child: SizedBox(
+                    width: isLandscape ? w * 0.5 : w,
+                    child: NestedScrollView(
+                      headerSliverBuilder: (c, bo) => [
+                        _buildLogoHeader(isDark),
+                        _buildSearchBar(context),
+                      ],
+                      body: isLoading
+                          ? Center(child: CircularProgressIndicator())
+                          : ListingFragment(data: users),
+                    ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/screens/home_view.dart
+++ b/lib/screens/home_view.dart
@@ -48,10 +48,12 @@ class _HomeViewState extends State<HomeView> {
 
   @override
   Widget build(BuildContext context) {
-    bool isLandscape =
+    final bool isLandscape =
         MediaQuery.of(context).orientation == Orientation.landscape;
-    bool isDark = Provider.of<DarkThemeProvider>(context).dTheme;
+    final bool isDark = Provider.of<DarkThemeProvider>(context).dTheme;
+    final String bgImage = Provider.of<DarkThemeProvider>(context).bgImg;
     final w = MediaQuery.of(context).size.width;
+    final h = MediaQuery.of(context).size.height;
 
     return GestureDetector(
       onTap: () => FocusManager.instance.primaryFocus
@@ -59,19 +61,33 @@ class _HomeViewState extends State<HomeView> {
       child: Scaffold(
         body: SafeArea(
           bottom: false,
-          child: Center(
-            child: SizedBox(
-              width: isLandscape ? w * 0.5 : w,
-              child: NestedScrollView(
-                headerSliverBuilder: (c, bo) => [
-                  _buildLogoHeader(isDark),
-                  _buildSearchBar(context),
-                ],
-                body: isLoading
-                    ? Center(child: CircularProgressIndicator())
-                    : ListingFragment(data: users),
+          child: Stack(
+            children: [
+              Container(
+                width: w,
+                height: h,
+                decoration: BoxDecoration(
+                  image: DecorationImage(
+                    image: AssetImage(bgImage),
+                    fit: BoxFit.fill,
+                  ),
+                ),
               ),
-            ),
+              Center(
+                child: SizedBox(
+                  width: isLandscape ? w * 0.5 : w,
+                  child: NestedScrollView(
+                    headerSliverBuilder: (c, bo) => [
+                      _buildLogoHeader(isDark),
+                      _buildSearchBar(context),
+                    ],
+                    body: isLoading
+                        ? Center(child: CircularProgressIndicator())
+                        : ListingFragment(data: users),
+                  ),
+                ),
+              ),
+            ],
           ),
         ),
       ),
@@ -103,7 +119,7 @@ class _HomeViewState extends State<HomeView> {
   SliverAppBar _buildSearchBar(BuildContext context) {
     return SliverAppBar(
       elevation: 0,
-      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      backgroundColor: Colors.transparent,
       pinned: true,
       titleSpacing: 0,
       title: SearchBar(

--- a/lib/themes/dark_theme.dart
+++ b/lib/themes/dark_theme.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 class DarkTheme {
@@ -28,6 +29,9 @@ class DarkTheme {
           colorScheme: isDarkTheme ? ColorScheme.dark() : ColorScheme.light()),
       appBarTheme: AppBarTheme(
         elevation: 0.0,
+        systemOverlayStyle: isDarkTheme
+            ? SystemUiOverlayStyle.light
+            : SystemUiOverlayStyle.dark,
       ),
     );
   }


### PR DESCRIPTION
1. Add background image on home_view.dart according to the type of theme
<img width="1440" alt="Screen Shot 2022-10-19 at 13 11 37" src="https://user-images.githubusercontent.com/44092368/196722617-0d6a88e3-47e9-45be-ad33-34a7b9e92e4f.png">
<img width="1440" alt="Screen Shot 2022-10-19 at 13 12 20" src="https://user-images.githubusercontent.com/44092368/196722687-fc4ee73e-ed99-44f4-aeac-e3056e7d083b.png">

2. Change the color of the status bar according to the type of theme. If the theme is dark, the color of the status bar will be drawn with a light color, and if the theme is light, the status bar will be drawn with dark color
<img width="408" alt="Screen Shot 2022-10-19 at 13 20 34" src="https://user-images.githubusercontent.com/44092368/196722881-0b61480a-65f3-4544-a1b3-253b9ae153af.png">
<img width="409" alt="Screen Shot 2022-10-19 at 13 20 47" src="https://user-images.githubusercontent.com/44092368/196723131-ee2d8b77-9f5d-4ae3-ab31-2abec37fac35.png">

3. Fixing bug text overflow found on iPhone 13
<img width="411" alt="Screen Shot 2022-10-19 at 13 22 21" src="https://user-images.githubusercontent.com/44092368/196723258-4ba2d559-496a-4450-a7da-299305b93649.png">
<img width="411" alt="Screen Shot 2022-10-19 at 21 06 36" src="https://user-images.githubusercontent.com/44092368/196723304-8ac71779-7fa6-4dff-bd96-8dafb44d2753.png">
<img width="1440" alt="Screen Shot 2022-10-19 at 21 05 28" src="https://user-images.githubusercontent.com/44092368/196723364-fa4b1e50-b7cb-4326-9a46-ba544eb7d6fa.png">